### PR TITLE
Fix #22 by adding intermediate copy step

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -3,7 +3,15 @@ import os
 import config
 
 #Remove truncated temporary files from downloads interrupted at the end of past runs
-for root, _, files in os.walk(config.imageDir):
-    for name in files:
-        if name[-4:] == '_tmp':
-            os.unlink(os.path.join(root, name))
+def cleanup():
+    cleanup(config.imageDir)
+
+
+def cleanup(path):
+    for root, _, files in os.walk(path):
+        for name in files:
+            if name[-4:] == "_tmp":
+                os.unlink(os.path.join(root, name))
+
+if __name__ == "__main__":
+    cleanup()

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,9 @@
+import os
+
+import config
+
+#Remove truncated temporary files from downloads interrupted at the end of past runs
+for root, _, files in os.walk(config.imageDir):
+    for name in files:
+        if name[-4:] == '_tmp':
+            os.unlink(os.path.join(root, name))

--- a/eve.py
+++ b/eve.py
@@ -369,7 +369,7 @@ class MediaFetcher(object):
             return
 
         #download the URL into a tempfile
-        tmp = tempfile.NamedTemporaryFile(delete = False) #FIXME handle leaks on error
+        tmp = tempfile.NamedTemporaryFile(delete = False, dir=destinationFolder, suffix="_tmp") #FIXME handle leaks on error
         url = "https://i.4cdn.org/{}/{}{}{}".format(self.board, tim, "s" if isPreview else "", ".jpg" if isPreview else ext)
 
         while True:
@@ -397,11 +397,8 @@ class MediaFetcher(object):
         tmp.close()
 
         #move the tempfile to the final file path
-        if os.stat(tmp.name).st_dev == os.stat(destinationFolder).st_dev: #Temp file and destination are on same device
-            shutil.move(tmp.name, destinationPath)                        #so copy is atomic
-        else:
-            shutil.move(tmp.name, destinationPath + '_tmp')
-            shutil.move(destinationPath + '_tmp', destinationPath)
+        #Temp file and destination are on same device so rename is atomic
+        os.rename(tmp.name, destinationPath)
 
         #set permissions on file path
         #webGroupId is never set in asagi, so should we even do this? Is this even relevant today?

--- a/eve.py
+++ b/eve.py
@@ -114,7 +114,7 @@ class Board(object):
         eventlet.spawn(self.threadListUpdater)
         eventlet.spawn(self.threadUpdateQueuer)
         eventlet.spawn(self.inserter)
-    
+
     def createTables(self):
         logger.warning("creating tables for "+self.board)
         with connectionPool.item() as conn:
@@ -143,7 +143,7 @@ class Board(object):
             for page in threadsJson:
                 for thread in page['threads']:
                     tmp.append(thread)
-            for priority, thread in enumerate(tmp[::-1]):#fetch oldest threads first 
+            for priority, thread in enumerate(tmp[::-1]):#fetch oldest threads first
                 if thread['no'] not in self.threads:
                     logger.debug("Thread %s is new, queueing", thread['no'])
                     self.threads[thread['no']] = thread
@@ -397,7 +397,11 @@ class MediaFetcher(object):
         tmp.close()
 
         #move the tempfile to the final file path
-        shutil.move(tmp.name, destinationPath)
+        if os.stat(tmp.name).st_dev == os.stat(destinationFolder).st_dev: #Temp file and destination are on same device
+            shutil.move(tmp.name, destinationPath)                        #so copy is atomic
+        else:
+            shutil.move(tmp.name, destinationPath + '_tmp')
+            shutil.move(destinationPath + '_tmp', destinationPath)
 
         #set permissions on file path
         #webGroupId is never set in asagi, so should we even do this? Is this even relevant today?

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -1,0 +1,15 @@
+import unittest
+import os
+import shutil
+
+import cleanup
+
+class TestCleanup(unittest.TestCase):
+    def test_cleanup(self):
+        cleanupDir = "cleanup_test"
+        os.mkdir(cleanupDir)
+        for i in ["a", "b_tmp", "c_tmp", "_tmpd"]:
+            open(os.path.join(cleanupDir, i), "a").close()
+        cleanup.cleanup(cleanupDir)
+        self.assertEqual(sorted(["a", "_tmpd"]), sorted(os.listdir(cleanupDir)))
+        shutil.rmtree(cleanupDir)


### PR DESCRIPTION
Fixed by checking if destination folder is on same device and if not,
first copying to a temporary filename, hence preventing truncation if
Eve is killed during a copy (as the file will not be shown as already
downloaded and will be downloaded again on the next run). Deletion of
temp files is done by running cleanup.py as this could potentially take
a while on a large archive, and temp files should be small and rarely
created.

Sorry if I've made any errors; this is my first pull request. I have only tested this on Linux.